### PR TITLE
Industrial miner unintentional fuel consuming fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -311,18 +311,16 @@ class MiningTask implements Runnable {
             for (MachineFuel fuelType : miner.fuelTypes) {
                 ItemStack item = inv.getContents()[i];
 
-                if (fuelType.test(item)) {
-                    /*
-                     * Fixes #3336
-                     * Respects the state of the miner if there are
-                     * no any errors during #setPistonState
-                     */
-                    if (running) {
-                        ItemUtils.consumeItem(item, false);
+                /*
+                 * Fixes #3336
+                 * Respects the state of the miner if there are
+                 * no any errors during #setPistonState
+                 */
+                if (fuelType.test(item) && running) {
+                    ItemUtils.consumeItem(item, false);
 
-                        if (miner instanceof AdvancedIndustrialMiner) {
-                            inv.addItem(new ItemStack(Material.BUCKET));
-                        }
+                    if (miner instanceof AdvancedIndustrialMiner) {
+                        inv.addItem(new ItemStack(Material.BUCKET));
                     }
 
                     return fuelType.getTicks();


### PR DESCRIPTION
## Description
Fixes the small bug from advanced industrial miner during warm-up phase, it should respect the ```#stop()``` boolean value if there are any errors during ```#setPistonState``` validation. Created a new branch.

## Proposed changes
- Prevent industrial miner from consuming fluid fuels if there are any error messages during ```#setPistonState```

## Related Issues (if applicable)
- Resolves #3336 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
